### PR TITLE
Use default GOPATH on go1.8+ if GOPATH is not defined

### DIFF
--- a/parser/go18.go
+++ b/parser/go18.go
@@ -1,0 +1,9 @@
+// +build go1.8
+
+package parser
+
+import (
+	"go/build"
+)
+
+var defaultGOPATH = build.Default.GOPATH

--- a/parser/not_go18.go
+++ b/parser/not_go18.go
@@ -1,0 +1,5 @@
+// +build !go1.8
+
+package parser
+
+var defaultGOPATH = ""

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -46,6 +46,9 @@ type ParsedStruct struct {
 func fileNameToPkgName(filePath, absFilePath string) string {
 	dir := filepath.Dir(absFilePath)
 	gopathEnv := os.Getenv("GOPATH")
+	if gopathEnv == "" {
+		gopathEnv = defaultGOPATH
+	}
 	gopaths := strings.Split(gopathEnv, string(os.PathListSeparator))
 	var inGoPath string
 	for _, gopath := range gopaths {


### PR DESCRIPTION
Go 1.8 introduces the [default GOPATH](https://github.com/golang/go/issues/17262), make sure go-queryset also uses the default GOPATH on Go1.8+ if no GOPATH env variable is set.

Otherwise go-queryset can't be used on a machine that has Go1.8+ and no GOPATH env variable set.