### PR TITLE
added quote option to escape column names

### DIFF
--- a/cmd/goqueryset/goqueryset.go
+++ b/cmd/goqueryset/goqueryset.go
@@ -17,6 +17,7 @@ func main() {
 	inFile := flag.String("in", "models.go", "path to input file")
 	outFile := flag.String("out", defaultOutPath, "path to output file")
 	timeout := flag.Duration("timeout", time.Minute, "timeout for generation")
+	quoteIdentifier := flag.String("quote", "", "the quote to be used to escape column names")
 	flag.Parse()
 
 	if *outFile == defaultOutPath {
@@ -30,7 +31,7 @@ func main() {
 	ctx, finish := context.WithTimeout(context.Background(), *timeout)
 	defer finish()
 
-	if err := g.Generate(ctx, *inFile, *outFile); err != nil {
+	if err := g.Generate(ctx, *inFile, *outFile, *quoteIdentifier); err != nil {
 		log.Fatalf("can't generate query sets: %s", err)
 	}
 }

--- a/internal/queryset/generator/generator.go
+++ b/internal/queryset/generator/generator.go
@@ -16,17 +16,18 @@ import (
 
 type Generator struct {
 	StructsParser *parser.Structs
+	quote         string
 }
 
 // Generate generates output file with querysets
-func (g Generator) Generate(ctx context.Context, inFilePath, outFilePath string) error {
+func (g Generator) Generate(ctx context.Context, inFilePath, outFilePath, quote string) error {
 	parsedFile, err := g.StructsParser.ParseFile(ctx, inFilePath)
 	if err != nil {
 		return errors.Wrapf(err, "can't parse file %s to get structs", inFilePath)
 	}
 
 	var r io.Reader
-	r, err = GenerateQuerySetsForStructs(parsedFile.Types, parsedFile.Structs)
+	r, err = GenerateQuerySetsForStructs(parsedFile.Types, quote, parsedFile.Structs)
 	if err != nil {
 		return errors.Wrap(err, "can't generate query sets")
 	}

--- a/internal/queryset/generator/methodsbuilder.go
+++ b/internal/queryset/generator/methodsbuilder.go
@@ -17,10 +17,10 @@ func (b *methodsBuilder) qsTypeName() string {
 	return b.s.TypeName + "QuerySet"
 }
 
-func newMethodsBuilder(s parser.ParsedStruct, fields []field.Info) *methodsBuilder {
+func newMethodsBuilder(s parser.ParsedStruct, quote string, fields []field.Info) *methodsBuilder {
 	return &methodsBuilder{
 		s:      s,
-		sctx:   methods.NewQsStructContext(s),
+		sctx:   methods.NewQsStructContext(s, quote),
 		fields: fields,
 	}
 }

--- a/internal/queryset/generator/queryset.go
+++ b/internal/queryset/generator/queryset.go
@@ -74,8 +74,11 @@ func genStructFieldInfos(s parser.ParsedStruct, types *types.Package) (ret []fie
 	return ret
 }
 
-func generateQuerySetConfigs(types *types.Package,
-	structs map[string]parser.ParsedStruct) querySetStructConfigSlice {
+func generateQuerySetConfigs(
+	types *types.Package,
+	quote string,
+	structs map[string]parser.ParsedStruct,
+) querySetStructConfigSlice {
 
 	querySetStructConfigs := querySetStructConfigSlice{}
 
@@ -85,7 +88,7 @@ func generateQuerySetConfigs(types *types.Package,
 		}
 
 		fields := genStructFieldInfos(s, types)
-		b := newMethodsBuilder(s, fields)
+		b := newMethodsBuilder(s, quote, fields)
 		methods := b.Build()
 
 		qsConfig := querySetStructConfig{
@@ -103,8 +106,12 @@ func generateQuerySetConfigs(types *types.Package,
 
 // GenerateQuerySetsForStructs is an internal method to retrieve querysets
 // generated code from parsed structs
-func GenerateQuerySetsForStructs(types *types.Package, structs map[string]parser.ParsedStruct) (io.Reader, error) {
-	querySetStructConfigs := generateQuerySetConfigs(types, structs)
+func GenerateQuerySetsForStructs(
+	types *types.Package,
+	quote string,
+	structs map[string]parser.ParsedStruct,
+) (io.Reader, error) {
+	querySetStructConfigs := generateQuerySetConfigs(types, quote, structs)
 	if len(querySetStructConfigs) == 0 {
 		return nil, nil
 	}

--- a/internal/queryset/methods/context.go
+++ b/internal/queryset/methods/context.go
@@ -6,12 +6,14 @@ import (
 )
 
 type QsStructContext struct {
-	s parser.ParsedStruct
+	s     parser.ParsedStruct
+	quote string
 }
 
-func NewQsStructContext(s parser.ParsedStruct) QsStructContext {
+func NewQsStructContext(s parser.ParsedStruct, quote string) QsStructContext {
 	return QsStructContext{
-		s: s,
+		s:     s,
+		quote: quote,
 	}
 }
 
@@ -39,7 +41,7 @@ func (ctx QsFieldContext) fieldName() string {
 }
 
 func (ctx QsFieldContext) fieldDBName() string {
-	return ctx.f.DBName
+	return ctx.quote + ctx.f.DBName + ctx.quote
 }
 
 func (ctx QsFieldContext) fieldTypeName() string {


### PR DESCRIPTION
The database throws syntax errror when reserved keywords are used as column names.