### PR TITLE
Added emplty line between package string and header comment

### DIFF
--- a/internal/queryset/generator/generator.go
+++ b/internal/queryset/generator/generator.go
@@ -51,6 +51,7 @@ func (g Generator) Generate(ctx context.Context, inFilePath, outFilePath string)
 
 func (g Generator) writeQuerySetsToOutput(r io.Reader, packageName, outFile string) error {
 	const hdrTmpl = `%s
+
 	package %s
 
 import (


### PR DESCRIPTION
Currently, the comment `// Code generated by go-queryset. DO NOT EDIT.` is inserted right before the `package ...` line. This causes the comment to be considered package documentation. Adding an empty line between the two makes it so, that this string is no longer package documentation.

I would argue that this is preferable, as the comment is only relevant for the one file and not the whole package and, as such, should not be package documentation.